### PR TITLE
Honor Content-Type headers with parameters

### DIFF
--- a/Sources/ResponseDetective.swift
+++ b/Sources/ResponseDetective.swift
@@ -97,9 +97,12 @@ import Foundation
 	///
 	/// - Returns: A body deserializer for given `contentType` or `nil`.
 	@objc(findBodyDeserializerForContentType:) private static func findBodyDeserializer(forContentType contentType: String) -> BodyDeserializer? {
+		guard let trimmedContentType = contentType.components(separatedBy: ";").first?.trimmingCharacters(in: .whitespaces) else {
+			return nil
+		}
 		for (pattern, deserializer) in defaultBodyDeserializers.appending(elementsOf: customBodyDeserializers) {
 			let patternParts = pattern.components(separatedBy: "/")
-			let actualParts = contentType.components(separatedBy: "/")
+			let actualParts = trimmedContentType.components(separatedBy: "/")
 			guard patternParts.count == 2 && actualParts.count == 2 else {
 				return nil
 			}

--- a/Tests/ResponseDetectiveSpec.swift
+++ b/Tests/ResponseDetectiveSpec.swift
@@ -104,9 +104,15 @@ internal final class ResponseDetectiveSpec: QuickSpec {
 						)
 					}
 
-					it("should return no deserialized body") {
+					it("should return a deserialized body") {
 						expect {
 							ResponseDetective.deserialize(body: Data(), contentType: "foo/bar")
+						}.to(equal("lorem ipsum"))
+					}
+
+					it("should return a deserialized body for content type containing properties") {
+						expect {
+							ResponseDetective.deserialize(body: Data(), contentType: "foo/bar; charset=utf8")
 						}.to(equal("lorem ipsum"))
 					}
 
@@ -121,7 +127,7 @@ internal final class ResponseDetectiveSpec: QuickSpec {
 						)
 					}
 
-					it("should return no deserialized body") {
+					it("should return a deserialized body") {
 						expect {
 							ResponseDetective.deserialize(body: Data(), contentType: "foo/baz")
 						}.to(equal("dolor sit amet"))


### PR DESCRIPTION
#### In this pull request...

Valid (per [RFC 7231](https://tools.ietf.org/html/rfc7231#section-3.1.1.5)) `Content-Type` headers containing parameters are now honored by ResponseDetective.

#### Impact

Fixes #24.