### PR TITLE
podspec: update path for source_files

### DIFF
--- a/ResponseDetective.podspec
+++ b/ResponseDetective.podspec
@@ -33,7 +33,7 @@ Pod::Spec.new do |spec|
     tag: spec.version.to_s
   }
 
-  spec.source_files = 'Sources'
+  spec.source_files = 'ResponseDetective/Sources'
 
   # Linking
 


### PR DESCRIPTION
due to the different folder hierarchy the path for 'source_files' need to be update from 'Sources' to 'ResponseDetective/Sources'