### PR TITLE
[RD-67] Add completion handler to URLProtocol class method: Will perform redirection …

### DIFF
--- a/ResponseDetective/Sources/URLProtocol.swift
+++ b/ResponseDetective/Sources/URLProtocol.swift
@@ -65,6 +65,7 @@ import Foundation
 	/// - SeeAlso: URLSessionTaskDelegate.urlSession(_:task:willPerformHTTPRedirection:newRequest:completionHandler:)
 	internal func urlSession(_ session: URLSession, task: URLSessionTask, willPerformHTTPRedirection response: HTTPURLResponse, newRequest request: URLRequest, completionHandler: @escaping (URLRequest?) -> Void) {
 		client?.urlProtocol(self, wasRedirectedTo: request, redirectResponse: response)
+        completionHandler(request)
 	}
 
 	/// - SeeAlso: URLSessionTaskDelegate.urlSession(_:task:didCompleteWithError:)


### PR DESCRIPTION
**Task Description**
Executing http requests that perform `redirection` (POST OR GET) requests 
and `Response Detective` is enabled we get this error in output console 

ScreenShot
<img width="1153" alt="Screenshot 2023-01-22 at 14 11 44" src="https://user-images.githubusercontent.com/33404419/213917636-f9999699-7338-4226-95ed-8642319da7e4.png">

[Original Issue](https://github.com/netguru/ResponseDetective/issues/67)

if we disabled `Response Detective` we didn't get that error because we use native URLProtocol class existed in URLSessionTaskDelegate that has  `task:willPerformHTTPRedirection:newRequest:completionHandler: completion` called completion handler at the end.

**Solution**
Adding completion handler to `task:willPerformHTTPRedirection:newRequest:completionHandler: completion` 
in NSURLSession delegate RDTURLProtocol this solve the issue




